### PR TITLE
Fix Jest + Babel

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  presets: [
+    ["@babel/preset-env", { useBuiltIns: "usage", corejs: 3 }],
+    ["@babel/preset-react", { runtime: "automatic" }],
+    "@babel/preset-typescript",
+  ],
+};

--- a/package.json
+++ b/package.json
@@ -23,26 +23,18 @@
     "@types/react-dom": "^17.0.11",
     "@vitejs/plugin-react": "^1.0.9",
     "babel-jest": "^27.3.1",
+    "core-js": "^3.19.1",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^27.3.1",
+    "regenerator-runtime": "^0.13.9",
     "typescript": "^4.5.2",
     "vite": "^2.6.14"
   },
-  "babel": {
-    "presets": [
-      "@babel/preset-env",
-      [
-        "@babel/preset-react",
-        {
-          "runtime": "automatic"
-        }
-      ],
-      "@babel/preset-typescript"
-    ]
-  },
   "jest": {
     "testEnvironment": "jsdom",
-    "transformIgnorePatterns": ["/node_modules/(?!@ionic/vue|@ionic/vue-router|@ionic/core|@stencil/core|ionicons)"],
+    "transformIgnorePatterns": [
+      "/node_modules/(?!(@ionic|@stencil|ionicons)/)"
+    ],
     "moduleNameMapper": {
       "\\.css$": "identity-obj-proxy"
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1804,6 +1804,11 @@ core-js-pure@^3.19.0:
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.19.1.tgz#edffc1fc7634000a55ba05e95b3f0fe9587a5aa4"
   integrity sha512-Q0Knr8Es84vtv62ei6/6jXH/7izKmOrtrxH9WJTHLCMAVeU+8TF8z8Nr08CsH4Ot0oJKzBzJJL9SJBYIv7WlfQ==
 
+core-js@^3.19.1:
+  version "3.19.1"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.19.1.tgz#f6f173cae23e73a7d88fa23b6e9da329276c6641"
+  integrity sha512-Tnc7E9iKd/b/ff7GFbhwPVzJzPztGrChB8X8GLqoYGdEOG8IpLnK1xPyo3ZoO3HsK6TodJS58VGPOxA+hLHQMg==
+
 cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
@@ -3278,7 +3283,7 @@ regenerate@^1.4.2:
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.2.tgz#b9346d8827e8f5a32f7ba29637d398b69014848a"
   integrity sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==
 
-regenerator-runtime@^0.13.4:
+regenerator-runtime@^0.13.4, regenerator-runtime@^0.13.9:
   version "0.13.9"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz#8925742a98ffd90814988d7566ad30ca3b263b52"
   integrity sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==


### PR DESCRIPTION
- Use 'babel.config.js' file for configuration because babel-jest has a hard time finding config in package.json, apparently
- Set useBuiltIns: "usage" to ensure core-js and regenerator-runtime get imported where they are needed (@ionic/@stencils need these but they have not emitted imports for them)
- Assume all @iconic, @stencil, and ionicons dependencies need transforming